### PR TITLE
Default to keeping the pumps

### DIFF
--- a/eventhubsprocessor/eph.py
+++ b/eventhubsprocessor/eph.py
@@ -49,5 +49,5 @@ class EPHOptions:
         self.max_batch_size = 10
         self.prefetch_count = 300
         self.receive_timeout = 60
-        self.release_pump_on_timeout = True
+        self.release_pump_on_timeout = False
         self.initial_offset_provider = "-1"


### PR DESCRIPTION
It is more optimal to keep the pumps alive even if there are no
messages so that it is faster to pickup when messages start to arrive.